### PR TITLE
Fix root selectors for MFEs

### DIFF
--- a/app-about/src/app/app.component.ts
+++ b/app-about/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 @Component({
-  selector: 'app-root',
+  selector: 'app-about-root',
   standalone: true,
   imports: [RouterOutlet],
   templateUrl: './app.component.html',

--- a/app-about/src/index.html
+++ b/app-about/src/index.html
@@ -8,6 +8,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <app-root></app-root>
+  <app-about-root></app-about-root>
 </body>
 </html>

--- a/app-about/src/main.single-spa.ts
+++ b/app-about/src/main.single-spa.ts
@@ -26,7 +26,7 @@ const lifecycles = singleSpaAngular({
       ],
     });
   },
-  template: '<app-root />',
+  template: '<app-about-root />',
   NgZone,
 });
 

--- a/app-home/src/app/app.component.ts
+++ b/app-home/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { singleSpaPropsSubject } from '../single-spa/single-spa-props';
 import { CommonModule } from '@angular/common';
 
 @Component({
-  selector: 'app-root',
+  selector: 'app-home-root',
   standalone: true,
   imports: [RouterOutlet, CommonModule],
   templateUrl: './app.component.html',

--- a/app-home/src/index.html
+++ b/app-home/src/index.html
@@ -8,6 +8,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <app-root></app-root>
+  <app-home-root></app-home-root>
 </body>
 </html>

--- a/app-home/src/main.single-spa.ts
+++ b/app-home/src/main.single-spa.ts
@@ -26,7 +26,7 @@ const lifecycles = singleSpaAngular({
       ],
     });
   },
-  template: '<app-root />',
+  template: '<app-home-root />',
   NgZone,
 });
 

--- a/app-nav/src/app/app.component.ts
+++ b/app-nav/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 @Component({
-  selector: 'app-root',
+  selector: 'app-nav-root',
   standalone: true,
   imports: [RouterOutlet],
   templateUrl: './app.component.html',

--- a/app-nav/src/index.html
+++ b/app-nav/src/index.html
@@ -8,6 +8,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <app-root></app-root>
+  <app-nav-root></app-nav-root>
 </body>
 </html>

--- a/app-nav/src/main.single-spa.ts
+++ b/app-nav/src/main.single-spa.ts
@@ -26,7 +26,7 @@ const lifecycles = singleSpaAngular({
       ],
     });
   },
-  template: '<app-root />',
+  template: '<app-nav-root />',
   NgZone,
 });
 


### PR DESCRIPTION
When navigating in the MFE the child routes are rendering into the nav MFE's root selector, which means it's destroying the existing MFE.